### PR TITLE
Update conditions for recognizing Zarr data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,5 +199,27 @@
 			<artifactId>n5</artifactId>
 			<version>2.5.1</version>
 		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+			<version>1.x-SNAPSHOT</version>
+			<systemPath>/home/useradmin/.m2/repository/net/imagej/ij/1.x-SNAPSHOT/ij-1.x-SNAPSHOT.jar</systemPath>
+			<scope>system</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-legacy</artifactId>
+			<version>0.38.0</version>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij1-patcher</artifactId>
+			<version>1.2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>IO_</artifactId>
+			<version>4.2.0</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/sc/fiji/ome/zarr/fiji/ui/DialogAroundZarr.java
+++ b/src/main/java/sc/fiji/ome/zarr/fiji/ui/DialogAroundZarr.java
@@ -33,7 +33,8 @@ public class DialogAroundZarr {
 					+zarrFolder.toAbsolutePath()+" or it is not a folder."
 					+" I need a top-level _folder_ to open.");
 
-		if (!zarrFolder.toString().endsWith(".ome.zarr"))
+		if (!(Files.exists(zarrFolder.resolve(".zgroup")) ||
+				Files.exists(zarrFolder.resolve(".zarray") )))
 			throw new IllegalArgumentException("The folder "
 					+zarrFolder.toAbsolutePath()+" is likely not a .ome.zarr");
 

--- a/src/main/java/sc/fiji/ome/zarr/fiji/ui/DndHandler.java
+++ b/src/main/java/sc/fiji/ome/zarr/fiji/ui/DndHandler.java
@@ -13,6 +13,7 @@ import org.scijava.io.location.FileLocation;
 import org.scijava.io.location.Location;
 import org.scijava.ui.UIService;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
@@ -24,9 +25,10 @@ public class DndHandler extends AbstractIOPlugin<Object> {
 
 	@Override
 	public boolean supportsOpen(Location source) {
-		logService.info("DnDHandler was questioned: "+source.getURI().getPath());
+		final String sourcePath = source.getURI().getPath();
+		logService.info("DnDHandler was questioned: "+sourcePath);
 		if (!(source instanceof FileLocation)) return false;
-		if (!(source.getName().endsWith(".zarr"))) return false;
+		if (!(new File(sourcePath, ".zgroup").exists() || new File(sourcePath, ".zarray").exists() ) ) return false;
 		return true;
 	}
 
@@ -40,7 +42,7 @@ public class DndHandler extends AbstractIOPlugin<Object> {
 		//
 		//we've been given a .zarr _file_, a special "tag" file inside .zarr,
 		//its parent folder is the true "handle" of this .zarr
-		new DialogAroundZarr(fsource.getFile().getParentFile().toPath());
+		new DialogAroundZarr(fsource.getFile().toPath());
 		return FAKE_INPUT;
 	}
 

--- a/src/main/java/sc/fiji/ome/zarr/fiji/ui/DndHandler.java
+++ b/src/main/java/sc/fiji/ome/zarr/fiji/ui/DndHandler.java
@@ -1,6 +1,8 @@
 package sc.fiji.ome.zarr.fiji.ui;
 
-import net.imagej.ImageJ;
+import net.imagej.legacy.ui.LegacyUI;
+
+import org.scijava.Context;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -9,6 +11,7 @@ import org.scijava.io.IOPlugin;
 import org.scijava.io.AbstractIOPlugin;
 import org.scijava.io.location.FileLocation;
 import org.scijava.io.location.Location;
+import org.scijava.ui.UIService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,8 +55,7 @@ public class DndHandler extends AbstractIOPlugin<Object> {
 
 	//--------------------------------------------------------
 	public static void main(String[] args) {
-		ImageJ ij = new ImageJ();
-		ij.ui().showUI();
-		ij.ui().show("try drag-and-dropping a .zarr _file_ ....");
+		final Context context = new Context();
+		context.service( UIService.class ).showUI( LegacyUI.NAME );
 	}
 }


### PR DESCRIPTION
## Update conditions for recognizing Zarr data
- directories that contain .zgroup or .zarray are recognized as Zarr data
## Updates for execution from IDE
- show ImageJ legacy UI
- add dependencies required to run from IDE